### PR TITLE
Fix Vercel login redirect to use production URL

### DIFF
--- a/yachty-app/.env.example
+++ b/yachty-app/.env.example
@@ -17,4 +17,6 @@ ONEDRIVE_CLIENT_SECRET=your_onedrive_client_secret
 ONEDRIVE_TENANT_ID=your_onedrive_tenant_id
 
 # App Configuration
+# Set this to your production URL on Vercel (e.g., https://your-app.vercel.app)
+# This is used for auth redirects - make sure to also whitelist this URL in Supabase dashboard
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/yachty-app/app/auth/login/page.tsx
+++ b/yachty-app/app/auth/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_URL || window.location.origin}/auth/callback`,
         },
       })
 


### PR DESCRIPTION
The login page was using window.location.origin for the auth redirect, which caused magic links to redirect to localhost instead of the production Vercel URL. Updated to use NEXT_PUBLIC_APP_URL environment variable with fallback to window.location.origin for local development.

Changes:
- Use NEXT_PUBLIC_APP_URL env var for emailRedirectTo in login page
- Add documentation to .env.example explaining the variable usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)