### PR TITLE
Fix magic link authentication callback to properly handle sessions

### DIFF
--- a/yachty-app/app/auth/callback/route.ts
+++ b/yachty-app/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
-import { createClient } from '@/lib/supabase/server'
+import { createServerClient } from '@supabase/ssr'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
@@ -8,8 +9,37 @@ export async function GET(request: NextRequest) {
   const origin = requestUrl.origin
 
   if (code) {
-    const supabase = await createClient()
-    await supabase.auth.exchangeCodeForSession(code)
+    const cookieStore = await cookies()
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll()
+          },
+          setAll(cookiesToSet) {
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options)
+              )
+            } catch (error) {
+              // Handle cookie setting errors
+              console.error('Error setting cookies:', error)
+            }
+          },
+        },
+      }
+    )
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (error) {
+      console.error('Error exchanging code for session:', error)
+      // Redirect to login with error
+      return NextResponse.redirect(`${origin}/auth/login?error=${encodeURIComponent(error.message)}`)
+    }
   }
 
   // URL to redirect to after sign in process completes

--- a/yachty-app/app/auth/login/page.tsx
+++ b/yachty-app/app/auth/login/page.tsx
@@ -1,13 +1,25 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, Suspense } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import { useSearchParams } from 'next/navigation'
 
-export default function LoginPage() {
+function LoginForm() {
   const [email, setEmail] = useState('')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const supabase = createClient()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const error = searchParams.get('error')
+    if (error) {
+      setMessage({
+        type: 'error',
+        text: `Authentication failed: ${error}`,
+      })
+    }
+  }, [searchParams])
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -96,5 +108,17 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+        <div className="text-gray-600">Loading...</div>
+      </div>
+    }>
+      <LoginForm />
+    </Suspense>
   )
 }


### PR DESCRIPTION
The magic link was redirecting users back to the login page because the auth callback route was not properly persisting the session cookies after exchanging the auth code.

Changes:
- Updated auth callback to use createServerClient directly with proper cookie handlers instead of the wrapper function
- Added error handling in callback with redirect to login page on failure
- Enhanced login page to display error messages from failed auth attempts
- Wrapped LoginForm in Suspense boundary to properly handle useSearchParams

This ensures that when users click the magic link, the session is correctly established and they are redirected to the home page instead of looping back to login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)